### PR TITLE
[issue-15] useMutateのトースト実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next-auth": "^4.24.5",
     "react": "^18",
     "react-dom": "^18",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^4.12.0",
     "server-only": "^0.0.1",
     "uuid": "^9.0.1",

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -4,6 +4,7 @@ import { FC, ReactNode } from "react"
 import { MantineProvider } from '@mantine/core'
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { SessionProvider } from "next-auth/react"
+import { Toaster } from "react-hot-toast"
 
 const queryClient = new QueryClient()
 
@@ -15,6 +16,9 @@ export const Providers: FC<ProvidersProps> = ({ children }) => {
     <QueryClientProvider client={queryClient}>
       <MantineProvider>
         <SessionProvider>
+          <Toaster
+            position="bottom-center"
+          />
           {children}
         </SessionProvider>
       </MantineProvider>

--- a/src/util/client/useMutate.tsx
+++ b/src/util/client/useMutate.tsx
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query"
+import toast from "react-hot-toast"
 
 interface UseMutateOptions {
   onSuccess: { toast: JSX.Element | string }
@@ -12,8 +13,20 @@ export const useMutate = <F extends ((...args: any[]) => Promise<any>)>(
   const { mutateAsync, isPending, isError, error, isSuccess } = useMutation({
     ...options,
     mutationFn: handler,
-    onSuccess: () => { /* TODO トーストの表示 */ },
-    onError: () => { /* TODO トーストの表示 */ },
+    onSuccess: () => {
+      if (options.onSuccess?.toast) {
+        toast.success(options.onSuccess.toast, {
+          position: "bottom-center",
+        })
+      }
+    },
+    onError: () => {
+      if (options.onError?.toast) {
+        toast.error(options.onError.toast, {
+          position: "bottom-center",
+        })
+      }
+    },
   })
   return {
     mutate: mutateAsync,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1408,6 +1408,11 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+goober@^2.1.10:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.13.tgz#e3c06d5578486212a76c9eba860cbc3232ff6d7c"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -2182,6 +2187,13 @@ react-dom@^18:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-icons@^4.12.0:
   version "4.12.0"


### PR DESCRIPTION

## 目的・解決すること

close #15 

## 変更内容

useMutateのonSuccess.toast/onError.toastを実装。
成功時や失敗時にトーストを表示する機能を追加。

## スクリーンショット

<!-- 見た目の変更がない場合は省略可 -->

## テスト項目

<!-- 
UIの変更がある場合
- [ ] スマホ、PCのサイズでレイアウトが崩れないことを確認した
 -->

## 自己評価

出来を10点満点で自己評価:
点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [ ] 実装できたのでチェックして欲しい。
- [ ] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [x] その他（下に記入）

レビューしない

## 備考
