### PR TITLE
[issue-48] ログイン画面の実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^1.0.7",
     "@mantine/carousel": "^7.2.1",
     "@mantine/core": "^7.2.1",
     "@mantine/hooks": "^7.2.1",

--- a/src/app/login/AlreadyLoginedAlert.tsx
+++ b/src/app/login/AlreadyLoginedAlert.tsx
@@ -1,0 +1,30 @@
+import { getSession } from "@/auth/server/auth"
+import { InfoIcon } from "@/components/Alert"
+import { Alert } from "@mantine/core"
+import { FC, Suspense } from "react"
+
+interface AlreadyLoginedAlertProps {
+}
+const AlreadyLoginedAlert: FC<AlreadyLoginedAlertProps> = () => {
+    return (
+        <Suspense>
+            <Content />
+        </Suspense>
+    )
+}
+
+export default AlreadyLoginedAlert
+
+interface ContentProps {
+}
+const Content: FC<ContentProps> = async () => {
+    const session = await getSession()
+    return (
+        session &&
+        <Alert
+            color="info"
+            title="既にログインしています。"
+            icon={<InfoIcon />}
+        />
+    )
+}

--- a/src/app/login/LoginButton.tsx
+++ b/src/app/login/LoginButton.tsx
@@ -1,19 +1,22 @@
 "use client"
 
+import { login } from "@/auth/client/login"
 import MutateButton from "@/components/MutateButton"
 import { useMutate } from "@/util/client/useMutate"
-import { signIn } from "next-auth/react"
+import { useSearchParams } from "next/navigation"
 import { FC } from "react"
 
 interface LoginButtonProps {
 }
 const LoginButton: FC<LoginButtonProps> = () => {
-    const login = useMutate(async () => {
-        await signIn("google")
+    const searchParams = useSearchParams()
+    const handleLogin = useMutate(async () => {
+        const callbackUrl = searchParams.get("callback") ?? "/"
+        await login({ callbackUrl })
     })
     return (
         <MutateButton
-            mutation={login}
+            mutation={handleLogin}
             variant="filled"
             size="lg"
             w="100%"

--- a/src/app/login/LoginButton.tsx
+++ b/src/app/login/LoginButton.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-
 import MutateButton from "@/components/MutateButton"
 import { useMutate } from "@/util/client/useMutate"
 import { signIn } from "next-auth/react"

--- a/src/app/login/LoginButton.tsx
+++ b/src/app/login/LoginButton.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+
+import MutateButton from "@/components/MutateButton"
+import { useMutate } from "@/util/client/useMutate"
+import { signIn } from "next-auth/react"
+import { FC } from "react"
+
+interface LoginButtonProps {
+}
+const LoginButton: FC<LoginButtonProps> = () => {
+    const login = useMutate(async () => {
+        await signIn("google")
+    })
+    return (
+        <MutateButton
+            mutation={login}
+            variant="filled"
+            size="lg"
+            w="100%"
+        >
+            Googleで ログイン
+        </MutateButton>
+    )
+}
+
+export default LoginButton

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,38 @@
+import { Card } from "@/components/Card"
+import { List, ListItem } from "@/components/List"
+import { PageTitle } from "@/components/PageTitle"
+import { Box, Center, Text } from "@mantine/core"
+import LoginButton from "./LoginButton"
+
+const LoginPage = () => {
+    return (
+        <Center py="lg">
+            <Card miw="fit-content" w="250px" maw="100%">
+                <PageTitle ta="center" mt="md">
+                    ログイン
+                </PageTitle>
+                <Box my="md">
+                    ログインすると、
+                    <List my="md">
+                        <ListItem>
+                            作品を
+                            <Text component="span" fw="bold">
+                                登録・いいね
+                            </Text>
+                            する
+                        </ListItem>
+                        <ListItem>
+                            <Text component="span" fw="bold">
+                                好きなもの名刺
+                            </Text>
+                            を作成する
+                        </ListItem>
+                    </List>
+                    などの機能を利用できるようになります。
+                </Box>
+                <LoginButton />
+            </Card>
+        </Center>
+    )
+}
+export default LoginPage

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,37 +1,44 @@
 import { Card } from "@/components/Card"
 import { List, ListItem } from "@/components/List"
 import { PageTitle } from "@/components/PageTitle"
-import { Box, Center, Text } from "@mantine/core"
+import { Box, Center, Stack, Text } from "@mantine/core"
 import LoginButton from "./LoginButton"
+import AlreadyLoginedAlert from "./AlreadyLoginedAlert"
 
-const LoginPage = () => {
+const LoginPage = async () => {
     return (
         <Center py="lg">
-            <Card miw="fit-content" w="250px" maw="100%">
-                <PageTitle ta="center" mt="md">
-                    ログイン
-                </PageTitle>
-                <Box my="md">
-                    ログインすると、
-                    <List my="md">
-                        <ListItem>
-                            作品を
-                            <Text component="span" fw="bold">
-                                登録・いいね
-                            </Text>
-                            する
-                        </ListItem>
-                        <ListItem>
-                            <Text component="span" fw="bold">
-                                好きなもの名刺
-                            </Text>
-                            を作成する
-                        </ListItem>
-                    </List>
-                    などの機能を利用できるようになります。
-                </Box>
-                <LoginButton />
-            </Card>
+            <Stack>
+
+                <AlreadyLoginedAlert />
+
+                <Card miw="fit-content" w="250px" maw="100%">
+                    <PageTitle ta="center" mt="md">
+                        ログイン
+                    </PageTitle>
+                    <Box my="md">
+                        ログインすると、
+                        <List my="md">
+                            <ListItem>
+                                作品を
+                                <Text component="span" fw="bold">
+                                    登録・いいね
+                                </Text>
+                                する
+                            </ListItem>
+                            <ListItem>
+                                <Text component="span" fw="bold">
+                                    好きなもの名刺
+                                </Text>
+                                を作成する
+                            </ListItem>
+                        </List>
+                        などの機能を利用できるようになります。
+                    </Box>
+                    <LoginButton />
+                </Card>
+
+            </Stack>
         </Center>
     )
 }

--- a/src/auth/client/login.tsx
+++ b/src/auth/client/login.tsx
@@ -1,0 +1,4 @@
+import { SignInOptions, signIn } from "next-auth/react";
+
+export const loginGoogle = (options: SignInOptions = {}) => signIn("google", options)
+export const login = loginGoogle

--- a/src/auth/client/logout.tsx
+++ b/src/auth/client/logout.tsx
@@ -1,0 +1,3 @@
+import { SignOutParams, signOut } from "next-auth/react";
+
+export const logout = (params: SignOutParams = {}) => signOut(params)

--- a/src/auth/server/options.ts
+++ b/src/auth/server/options.ts
@@ -1,9 +1,12 @@
-import "server-only"
+import "server-only";
 
-import { NextAuthOptions } from "next-auth"
-import GoogleProvider from "next-auth/providers/google"
+import { prisma } from "@/prisma";
+import { PrismaAdapter } from "@auth/prisma-adapter";
+import { NextAuthOptions } from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
 
 export const options: NextAuthOptions = {
+    adapter: PrismaAdapter(prisma),
     providers: [
         GoogleProvider({
             clientId: process.env.GOOGLE_AUTH_CLIENT_ID as string,
@@ -17,6 +20,7 @@ export const options: NextAuthOptions = {
             },
         }),
     ],
+    session: { strategy: "database" },
     callbacks: {
         session: ({ session, user }) => {
             if (session.user) {
@@ -24,5 +28,5 @@ export const options: NextAuthOptions = {
             }
             return session
         },
-    }
+    },
 }

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,9 @@
+import { Alert as MAlert } from "@mantine/core"
+import { ComponentProps } from "react"
+import { IoMdInformationCircleOutline } from "react-icons/io"
+
+export const Alert = MAlert
+
+export const InfoIcon = (props: ComponentProps<typeof IoMdInformationCircleOutline>) => {
+    return <IoMdInformationCircleOutline {...props} />
+}

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,0 +1,5 @@
+"use client"
+import { List as MList } from "@mantine/core"
+
+export const List = MList
+export const ListItem = MList.Item

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,25 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@auth/core@0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@auth/core/-/core-0.18.2.tgz#21fff058cc62509c408db1e7d36c9698b059ad17"
+  integrity sha512-pjTS0ReNNgZgUJPuuAwlp9wA+wu5ko0fX1KTTCgbuYioo9OVvUz6L3LV9+1hS4BtFw6yBtv6fVCLwCDu68/dQw==
+  dependencies:
+    "@panva/hkdf" "^1.1.1"
+    cookie "0.5.0"
+    jose "^5.1.0"
+    oauth4webapi "^2.3.0"
+    preact "10.11.3"
+    preact-render-to-string "5.2.3"
+
+"@auth/prisma-adapter@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@auth/prisma-adapter/-/prisma-adapter-1.0.7.tgz#1adcebd5100a2906706b46c063925a86b2f0166d"
+  integrity sha512-n8Q352QZroHrhUYwYgKMjNvCTgUKpHRnMlqxRU13gkxWe4NVXC17xmd+S61xKj0kVDnH12QhMjI6ToQQNSEkyw==
+  dependencies:
+    "@auth/core" "0.18.2"
+
 "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.7":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
@@ -213,7 +232,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@panva/hkdf@^1.0.2":
+"@panva/hkdf@^1.0.2", "@panva/hkdf@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@panva/hkdf/-/hkdf-1.1.1.tgz#ab9cd8755d1976e72fc77a00f7655a64efe6cd5d"
   integrity sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==
@@ -742,7 +761,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
-cookie@^0.5.0:
+cookie@0.5.0, cookie@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
@@ -1718,6 +1737,11 @@ jose@^4.11.4, jose@^4.15.1:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
   integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
 
+jose@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.1.1.tgz#d61b923baa6bdeb01040afae8295a084c4b9eb58"
+  integrity sha512-bfB+lNxowY49LfrBO0ITUn93JbUhxUN8I11K6oI5hJu/G6PO6fEUddVLjqdD0cQ9SXIHWXuWh7eJYwZF7Z0N/g==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1907,6 +1931,11 @@ next@14.0.1:
     "@next/swc-win32-arm64-msvc" "14.0.1"
     "@next/swc-win32-ia32-msvc" "14.0.1"
     "@next/swc-win32-x64-msvc" "14.0.1"
+
+oauth4webapi@^2.3.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/oauth4webapi/-/oauth4webapi-2.4.0.tgz#2a5e75996a33878cced3f367753aa42f21d36e27"
+  integrity sha512-ZWl8ov8HeGVyc9Icl1cag76HvIcDAp23eIIT+UVGir+dEu8BMgMlvZeZwqLVd0P8DqaumH4N+QLQXN69G1QjSA==
 
 oauth@^0.9.15:
   version "0.9.15"
@@ -2132,12 +2161,24 @@ postcss@8.4.31, postcss@^8.4.31:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+preact-render-to-string@5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz#23d17376182af720b1060d5a4099843c7fe92fe4"
+  integrity sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==
+  dependencies:
+    pretty-format "^3.8.0"
+
 preact-render-to-string@^5.1.19:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz#0ff0c86cd118d30affb825193f18e92bd59d0604"
   integrity sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==
   dependencies:
     pretty-format "^3.8.0"
+
+preact@10.11.3:
+  version "10.11.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.11.3.tgz#8a7e4ba19d3992c488b0785afcc0f8aa13c78d19"
+  integrity sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==
 
 preact@^10.6.3:
   version "10.19.2"


### PR DESCRIPTION

## 目的・解決すること

close #48 

## 変更内容

- ログイン画面を `/login` に実装
- ログイン/ログアウトするための関数 `login` と `logout` を実装

## スクリーンショット

<!-- 見た目の変更がない場合は省略可 -->

### 未ログイン時

<img width="598" alt="スクリーンショット 2023-11-21 21 20 28" src="https://github.com/megane-s/minshumi-frontend/assets/81161390/55c55b95-edab-4dd1-b0ab-9c26697adb7a">

### ログイン時

<img width="598" alt="スクリーンショット 2023-11-21 21 20 44" src="https://github.com/megane-s/minshumi-frontend/assets/81161390/85861df4-9f4c-49e0-9971-6dc4558889ef">


## テスト項目

<!-- 
UIの変更がある場合
- [ ] スマホ、PCのサイズでレイアウトが崩れないことを確認した
 -->

## 自己評価

出来を10点満点で自己評価:
8点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [x] 実装できたのでチェックして欲しい。
- [ ] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [ ] その他（下に記入）

## 備考

影響範囲大きめなので早めにマージしたいー

