### PR TITLE
ログインメニューから自分のプロフィール画面に移動する機能を実装

### DIFF
--- a/src/app/BaseLayout/HeaderMenu.tsx
+++ b/src/app/BaseLayout/HeaderMenu.tsx
@@ -13,6 +13,7 @@ import { EditIcon } from "@/components/icon/Edit";
 import { NotificationIcon } from "@/components/icon/Notification";
 import { SettingsIcon } from "@/components/icon/Settings";
 import { css } from "styled-system/css";
+import { CgProfile } from "react-icons/cg";
 
 interface HeaderMenuProps {
     session: Session | null
@@ -50,6 +51,13 @@ const HeaderMenu: FC<HeaderMenuProps> = ({ session }) => {
                         rightSection={<EditIcon />}
                         component={Link}
                         href="/art/new"
+                        onClick={close}
+                    />
+                    <NavLink
+                        label="MYプロフィール"
+                        rightSection={<CgProfile />}
+                        component={Link}
+                        href={`/user/${session.user.id}`}
                         onClick={close}
                     />
                     <NavLink


### PR DESCRIPTION

## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #163

## 変更内容

<!-- 
 変更した点を簡潔に記入してください
-->
ログインメニューに自分のプロフィール画面に移動する機能を実装
## 動作確認の手順と項目

<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット
![スクリーンショット 2024-01-11 140324](https://github.com/megane-s/minshumi-frontend/assets/148510436/08f561cf-1bae-4d83-829b-ccd39cacef12)
![スクリーンショット 2024-01-11 140248](https://github.com/megane-s/minshumi-frontend/assets/148510436/9d2509f0-bb25-431a-b781-c01861949a94)
![スクリーンショット 2024-01-11 140303](https://github.com/megane-s/minshumi-frontend/assets/148510436/168c4842-65a1-4a55-a5e4-eca230e4bef3)

<!-- 
 見た目の変更がない場合は省略可 
-->

## 自己評価

出来を10点満点で自己評価:

7点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [x] 実装できたのでチェックして欲しい。
- [x] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [ ] その他（下に記入）

## 備考
自分のプロフィールは「MYプロフィール」名前でよさそう？