### PR TITLE
[issue-165]プロフィール画面内に今見ている作品や好きな作品の編集ボタンを実装

### DIFF
--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -92,8 +92,8 @@ const UserProfilePage = async ({ params }: PageProps) => {
             </Flex>
 
             {/* TODO 作品表示の部分をカルーセルを使う */}
-            <Flex w="100%" justify="space-between" className={css({ mt: "lg", mb: "sm" })}>
-                <SectionTitle my="md" >
+            <Flex w="100%" justify="space-between" >
+                <SectionTitle >
                     好きな作品
                 </SectionTitle>
                 {loginUser && (user.id === loginUser?.id
@@ -111,7 +111,7 @@ const UserProfilePage = async ({ params }: PageProps) => {
             />
             {/* TODO 0件の時の表示 */}
             <Flex w="100%" justify="space-between" className={css({ mt: "lg", mb: "sm" })}>
-                <SectionTitle my="md">
+                <SectionTitle >
                     今見ている作品
                 </SectionTitle>
                 {loginUser && (user.id === loginUser?.id

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -97,8 +97,7 @@ const UserProfilePage = async ({ params }: PageProps) => {
                     好きな作品
                 </SectionTitle>
                 {loginUser && (user.id === loginUser?.id
-                    /* TODO 編集ボタンを押すと該当のページ先に移動 */
-                    ? <LinkButton href="/settings">
+                    ? <LinkButton href="/settings/like-arts">
                         好きな作品を編集する
                     </LinkButton>
                     : null
@@ -115,8 +114,7 @@ const UserProfilePage = async ({ params }: PageProps) => {
                     今見ている作品
                 </SectionTitle>
                 {loginUser && (user.id === loginUser?.id
-                    /* TODO 編集ボタンを押すと該当のページ先に移動 */
-                    ? <LinkButton href="/settings">
+                    ? <LinkButton href="/settings/watching-arts">
                         今見ている作品を編集する
                     </LinkButton>
                     : null

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -92,17 +92,36 @@ const UserProfilePage = async ({ params }: PageProps) => {
             </Flex>
 
             {/* TODO 作品表示の部分をカルーセルを使う */}
-            <SectionTitle my="md">
-                好きな作品
-            </SectionTitle>
+            <Flex w="100%" justify="space-between" className={css({ mt: "lg", mb: "sm" })}>
+                <SectionTitle my="md" >
+                    好きな作品
+                </SectionTitle>
+                {loginUser && (user.id === loginUser?.id
+                    /* TODO 編集ボタンを押すと該当のページ先に移動 */
+                    ? <LinkButton href="/settings">
+                        好きな作品を編集する
+                    </LinkButton>
+                    : null
+                )}
+
+            </Flex>
+
             <LikeArtList
                 arts={artAppeals}
             />
             {/* TODO 0件の時の表示 */}
-
-            <SectionTitle my="md">
-                今見ている作品
-            </SectionTitle>
+            <Flex w="100%" justify="space-between" className={css({ mt: "lg", mb: "sm" })}>
+                <SectionTitle my="md">
+                    今見ている作品
+                </SectionTitle>
+                {loginUser && (user.id === loginUser?.id
+                    /* TODO 編集ボタンを押すと該当のページ先に移動 */
+                    ? <LinkButton href="/settings">
+                        今見ている作品を編集する
+                    </LinkButton>
+                    : null
+                )}
+            </Flex>
             <WatchingArtList arts={watchingArts} />
             {/* TODO 0件の時の表示 */}
 


### PR DESCRIPTION

## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #165

## 変更内容
プロフィール画面内に今見ている作品や好きな作品の編集ボタンを実装
<!-- 
 変更した点を簡潔に記入してください
-->

## 動作確認の手順と項目
自分のプロフィールだと編集ボタンが表示される

他人のプロフィールだと編集ボタンが非表示
<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット
自分のプロフィール
![スクリーンショット 2024-01-11 155225](https://github.com/megane-s/minshumi-frontend/assets/148510436/8b9abbf2-55b4-4b12-9b3f-ab605a1b12e9)
他人のプロフィール
![スクリーンショット 2024-01-11 155355](https://github.com/megane-s/minshumi-frontend/assets/148510436/527329dd-385a-4a59-9e73-fcdf9cb1bef7)


<!-- 
 見た目の変更がない場合は省略可 
-->

## 自己評価

出来を10点満点で自己評価:

5点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [x] 実装できたのでチェックして欲しい。
- [x] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [x] その他（下に記入）

## 備考
- ボタンを実装しただけで、
ボタンを押下後のリンク先はまだ実装していない。
- ボタンのデザインがちょっと地味
- 編集ボタンの位置が気になる