### PR TITLE
[issue-164]作品詳細画面に編集ボタンを実装

### DIFF
--- a/src/app/art/[art_id]/page.tsx
+++ b/src/app/art/[art_id]/page.tsx
@@ -11,6 +11,7 @@ import { getSession } from "@/auth/server/auth"
 import { isArtGooded } from "@/art/good/isGooded"
 import { getTags } from "@/art/tag/getTags"
 import { css } from "styled-system/css"
+import LinkButton from "@/components/LinkButton"
 
 
 interface ArtDetailPageProps {
@@ -23,6 +24,7 @@ const ArtDetailPage = async ({ params }: ArtDetailPageProps) => {
     const tags = await getTags(artId)
     const session = await getSession()
     const isLogined = !!session
+    const loginUser = session?.user
     const isGooded = session ? await isArtGooded(artId, session.user.id) : false
 
     if (!art) notFound()
@@ -57,8 +59,16 @@ const ArtDetailPage = async ({ params }: ArtDetailPageProps) => {
                                 </Badge>
                             </Link>
                         )}
+
                     </Flex>
+                    {loginUser
+                        ? <LinkButton href={`${artId}/edit`}>
+                            編集する
+                        </LinkButton>
+                        : null
+                    }
                 </Container>
+
                 <Divider />
             </FullWidth>
 

--- a/src/app/art/[art_id]/page.tsx
+++ b/src/app/art/[art_id]/page.tsx
@@ -62,7 +62,7 @@ const ArtDetailPage = async ({ params }: ArtDetailPageProps) => {
 
                     </Flex>
                     {loginUser
-                        ? <LinkButton href={`${artId}/edit`}>
+                        ? <LinkButton href={`/art/${artId}/edit`}>
                             編集する
                         </LinkButton>
                         : null


### PR DESCRIPTION

## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #164

## 変更内容
作品詳細画面に編集ボタンを実装
<!-- 
 変更した点を簡潔に記入してください
-->

## 動作確認の手順と項目
![Animation6](https://github.com/megane-s/minshumi-frontend/assets/148510436/ffe91364-05d8-4c1a-868e-e3a08fef460e)

<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット
![スクリーンショット 2024-01-12 095950](https://github.com/megane-s/minshumi-frontend/assets/148510436/18c78cf0-2712-4c16-b830-d888891fb894)
![スクリーンショット 2024-01-12 100050](https://github.com/megane-s/minshumi-frontend/assets/148510436/14ef5c75-7276-4c35-8922-023602904cb1)
ログインしていないユーザは編集を非表示に
<!-- 
 見た目の変更がない場合は省略可 
-->

## 自己評価

出来を10点満点で自己評価:

9点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [x] 実装できたのでチェックして欲しい。
- [] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [x] その他（下に記入）

## 備考
issueのタイトルに「作品編集画面までのリンクボタンをタイトル横に追加」
と書いていあるが、
タイトルの長さによって、編集ボタン（リンクボタン）の位置が変わるため
固定するためにタグの下に置いてみました
![スクリーンショット 2024-01-12 095950](https://github.com/megane-s/minshumi-frontend/assets/148510436/18c78cf0-2712-4c16-b830-d888891fb894)