### PR TITLE
[issue-189] 画像ダウンロードボタンを設置

### DIFF
--- a/src/app/businesscard/[businesscard_id]/edit/BusinessCardEditor.tsx
+++ b/src/app/businesscard/[businesscard_id]/edit/BusinessCardEditor.tsx
@@ -22,6 +22,8 @@ import { handleSaveBusinessCard } from "./actions"
 import { useRouter } from "next/navigation"
 import { defaultBusinessCard } from "@/businessCard/defaults"
 import { User } from "next-auth"
+import LinkButton from "@/components/LinkButton"
+import { buildImageUrlParams } from "@/businessCard/buildImageUrlParams"
 
 
 interface BusinessCardEditorProps {
@@ -206,32 +208,117 @@ export const BusinessCardEditor: FC<BusinessCardEditorProps> = ({ defaultValues,
                 </div>
             </div>
 
-            {!isInstant &&
-                <div className={flex({
-                    position: "fixed !important", bottom: 2, right: 4, zIndex: 1,
-                    gap: "sm",
-                    base: { flexDir: "column", alignItems: "flex-end" },
-                    sm: { flexDir: "row" },
-                })}>
-                    <MutateButton
-                        mutation={save}
-                        className={css({ shadow: { base: "md", _active: "xs" }, transition: "box-shadow 0.3s" })}
-                        size="md"
-                        variant="default"
-                    >
-                        保存
-                    </MutateButton>
-                    <MutateButton
-                        className={css({ shadow: { base: "md", _active: "xs" }, transition: "box-shadow 0.3s" })}
-                        size="md"
-                        variant="filled"
-                        mutation={gotoSettings}
-                    >
-                        公開設定
-                    </MutateButton>
-                </div>
-            }
+            <div className={flex({
+                position: "fixed !important", bottom: 2, right: 4, zIndex: 1,
+                gap: "sm",
+                base: { flexDir: "column", alignItems: "flex-end" },
+                sm: { flexDir: "row" },
+            })}>
+                {isInstant
+                    ?
+                    <DownloadButton
+                        {...isValid
+                            ? {
+                                name,
+                                icon,
+                                rank,
+                                interestTags,
+                                arts,
+                                backgroundImage,
+                                themeColor,
+                                isValid: true,
+                            }
+                            : {
+                                name,
+                                icon,
+                                rank: rank ?? undefined,
+                                interestTags,
+                                arts,
+                                backgroundImage,
+                                themeColor: themeColor ?? undefined,
+                                isValid: false,
+                            }
+                        }
+                    />
+                    : <>
+                        <MutateButton
+                            mutation={save}
+                            className={buttonShadow}
+                            size="md"
+                            variant="default"
+                        >
+                            保存
+                        </MutateButton>
+                        <MutateButton
+                            className={buttonShadow}
+                            size="md"
+                            variant="filled"
+                            mutation={gotoSettings}
+                        >
+                            公開設定
+                        </MutateButton>
+                    </>
+                }
+            </div>
 
         </FullWidth >
     )
 }
+
+const buttonShadow = css({ shadow: { base: "md", _active: "xs" }, transition: "box-shadow 0.3s" })
+
+type DownloadButtonProps =
+    | (
+        {
+            name: string
+            icon: string
+            rank: string | null
+            interestTags: ArtTag[]
+            arts: string[]
+            backgroundImage: string
+            themeColor: string
+            isValid: true
+        }
+    )
+    | (
+        Partial<{
+            name: string
+            icon: string
+            rank: string | null
+            interestTags: ArtTag[]
+            arts: string[]
+            backgroundImage: string
+            themeColor: string
+        }> & {
+            isValid: false
+        }
+    )
+const DownloadButton: FC<DownloadButtonProps> = (props) => {
+    const params = props.isValid && new URLSearchParams(buildImageUrlParams({
+        type: "1",
+        username: props.name,
+        icon: props.icon,
+        interestTags: props.interestTags,
+        arts: props.arts,
+        backgroundImage: props.backgroundImage,
+        themeColor: props.themeColor,
+        rank: props.rank ?? "",
+    }))
+
+    const imageUrl = `/api/businesscard/image?${params.toString()}`
+
+    return (
+        <LinkButton
+            className={buttonShadow}
+            size="md"
+            variant="filled"
+            href={imageUrl}
+            download={props.name ? `${props.name}の名刺` : "名刺"}
+            target="_blank"
+        >
+            画像ダウンロード
+        </LinkButton>
+    )
+}
+
+export default DownloadButton

--- a/src/app/businesscard/[businesscard_id]/edit/BusinessCardPreview.tsx
+++ b/src/app/businesscard/[businesscard_id]/edit/BusinessCardPreview.tsx
@@ -8,6 +8,7 @@ import { useDebounce } from "react-use"
 import { css, cx } from "styled-system/css"
 import { colors } from "./colors"
 import { Loader } from "@/components/Loader"
+import { buildImageUrlParams } from "@/businessCard/buildImageUrlParams"
 
 interface BusinessCardPreviewProps {
     name: string,
@@ -78,15 +79,16 @@ export const BusinessCardPreview: FC<BusinessCardPreviewProps> = (props) => {
 
 
 export const usePreviewImageUrl = (input: BusinessCardPreviewProps) => {
-    const params = input && new URLSearchParams({
+    const params = input && new URLSearchParams(buildImageUrlParams({
         type: "1",
         username: input.name,
         icon: input.icon,
-        interest_tags: input.interestTags.join(","),
-        arts: input.arts.join(","),
-        background_image: input.backgroundImage,
-        theme_color: input.themeColor,
-    })
+        interestTags: input.interestTags,
+        arts: input.arts,
+        backgroundImage: input.backgroundImage,
+        themeColor: input.themeColor,
+        rank: input.rank,
+    }))
     params.append("rank", input.rank ?? "")
 
     const previewImageUrl = `/api/businesscard/image?${params.toString()}`

--- a/src/businessCard/buildImageUrlParams.ts
+++ b/src/businessCard/buildImageUrlParams.ts
@@ -1,0 +1,42 @@
+import { BusinessCard, BusinessCardInterestTag, BusinessCardLikeArt } from "./type"
+
+export const buildImageUrlParams = ({
+    type, username, icon, interestTags, arts, backgroundImage, themeColor, rank,
+}: {
+    type: string
+    username: string
+    icon: string
+    interestTags: string[],
+    arts: string[],
+    backgroundImage: string,
+    themeColor: string,
+    rank: string | null,
+}) => {
+    const params = {
+        type,
+        username,
+        icon,
+        interestTags: interestTags.join(","),
+        arts: arts.join(","),
+        background_image: backgroundImage,
+        theme_color: themeColor,
+        rank: rank ?? "",
+    }
+    return params
+}
+
+export const buildImageUrlParamsFromBusinessCard = (
+    businessCard: BusinessCard,
+    interestTags: BusinessCardInterestTag[],
+    arts: BusinessCardLikeArt[],
+) =>
+    buildImageUrlParams({
+        type: businessCard.type,
+        username: businessCard.name,
+        icon: businessCard.imageUrl,
+        interestTags,
+        arts,
+        backgroundImage: businessCard.backgroundImageUrl,
+        themeColor: businessCard.themeColor,
+        rank: businessCard.rank,
+    })

--- a/src/businessCard/type.ts
+++ b/src/businessCard/type.ts
@@ -2,11 +2,20 @@
 // eslint-disable-next-line no-restricted-imports
 import {
     BusinessCard as GeneratedBusinessCard,
-    BusinessCardSchema as GeneratedBusinessCardSchema
+    BusinessCardInterestTagSchema as GeneratedBusinessCardInterestTagSchema,
+    BusinessCardLikeArtSchema as GeneratedBusinessCardLikeArtSchema,
+    BusinessCardSchema as GeneratedBusinessCardSchema,
 } from "@/prisma/generated";
+import { z } from "zod";
 
 export const BusinessCardSchema = GeneratedBusinessCardSchema
 export type BusinessCard = GeneratedBusinessCard
 
 export const BusinessCardIdSchema = GeneratedBusinessCardSchema.shape.businessCardId
 export type BusinessCardId = GeneratedBusinessCard["businessCardId"]
+
+export const BusinessCardInterestTagSchema = GeneratedBusinessCardInterestTagSchema.shape.tag
+export type BusinessCardInterestTag = z.infer<typeof BusinessCardInterestTagSchema>
+
+export const BusinessCardLikeArtSchema = GeneratedBusinessCardLikeArtSchema.shape.likeArtTitle
+export type BusinessCardLikeArt = z.infer<typeof BusinessCardLikeArtSchema>


### PR DESCRIPTION

## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #189

## 変更内容

<!-- 
 変更した点を簡潔に記入してください
-->

名刺編集画面に画像ダウンロードボタンを追加。

## 動作確認の手順と項目

<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット

<!-- 
 見た目の変更がない場合は省略可 
-->

<img width="395" alt="スクリーンショット 2024-01-14 2 54 20" src="https://github.com/megane-s/minshumi-frontend/assets/81161390/5e675f38-3884-4341-a334-906ad0459db5">


## 自己評価

出来を10点満点で自己評価:

7点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [ ] 実装できたのでチェックして欲しい。
- [x] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [x] その他（下に記入）

時間ないのでレビューしない

## 備考
