### PR TITLE
[issue-173] クエリ更新時に選択している作品をリセットするように修正

### DIFF
--- a/src/art/components/appeal/EditArtDialog/Select.tsx
+++ b/src/art/components/appeal/EditArtDialog/Select.tsx
@@ -32,7 +32,7 @@ export const SelectRelatedArt: FC<SelectRelatedArtProps> = ({ defaultArtId, onGo
         <div>
             <SelectArt
                 selectArtId={selectedArtId}
-                onSelectArt={({ artId }) => setSelectedArtId(artId)}
+                onSelectArt={(art) => setSelectedArtId(art?.artId ?? null)}
                 autoFocus
             />
 


### PR DESCRIPTION
## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #173

## 変更内容

<!-- 
 変更した点を簡潔に記入してください
-->

クエリ更新時に選択している作品をリセットするよう修正。

## 動作確認の手順と項目

<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット

<!-- 
 見た目の変更がない場合は省略可 
-->


https://github.com/megane-s/minshumi-frontend/assets/81161390/99cfdf7c-bf1a-495b-8ac4-70728d870f8b



## 自己評価

出来を10点満点で自己評価:

8点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [ ] 実装できたのでチェックして欲しい。
- [x] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [x] その他（下に記入）

時間がないのでレビューしない

## 備考
