### PR TITLE
[issue-160] 設定画面の興味タグタブを実装

### DIFF
--- a/src/app/art/[art_id]/edit/tag/page.tsx
+++ b/src/app/art/[art_id]/edit/tag/page.tsx
@@ -2,8 +2,7 @@ import { getArt } from "@/art/get"
 import { EditArtTagForm } from "./EditArtTagForm"
 import { notFound } from "next/navigation"
 import { getTags } from "@/art/tag/getTags"
-import { getGenreTags, medias, others } from "@/art/components/tag/tags"
-import { ArtTag } from "@/art/type"
+import { splitTags } from "@/art/tag/split"
 
 interface PageProps {
     params: { art_id: string }
@@ -31,35 +30,3 @@ const ArtEditTagPage = async ({ params: { art_id } }: PageProps) => {
 }
 export default ArtEditTagPage
 
-const splitTags = (tags: ArtTag[]) => {
-    const mediaTags: ArtTag[] = []
-    const genreTags: ArtTag[] = []
-    const otherTags: ArtTag[] = []
-    // media と other
-    const notGroupedTags: ArtTag[] = []
-    tags.forEach((tag) => {
-        if (medias.includes(tag)) {
-            mediaTags.push(tag)
-        } else if (others.includes(tag)) {
-            otherTags.push(tag)
-        } else {
-            notGroupedTags.push(tag)
-        }
-    })
-    // genre
-    const genres = getGenreTags(mediaTags)
-    notGroupedTags.forEach((tag, index) => {
-        if (genres.includes(tag)) {
-            genreTags.push(tag)
-            notGroupedTags.splice(index, 1)
-        }
-    })
-    // originalTags
-    const originalTags: ArtTag[] = notGroupedTags
-    return {
-        mediaTags,
-        genreTags,
-        otherTags,
-        originalTags,
-    }
-}

--- a/src/app/settings/interest-tags/InterestTagsSettingForm.tsx
+++ b/src/app/settings/interest-tags/InterestTagsSettingForm.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { ArtTagForm } from "@/art/components/tag/ArtTagForm"
+import { getGenreTags, medias, others } from "@/art/components/tag/tags"
+import { ArtTag } from "@/art/type"
+import MutateButton from "@/components/MutateButton"
+import { CheckIcon } from "@/components/icon/Check"
+import { useMutate } from "@/util/client/useMutate"
+import { FC, useState } from "react"
+import { center } from "styled-system/patterns"
+import { handleUpdateInterestTags } from "./actions"
+
+interface InterestTagsSettingFormProps {
+    defaultValues: {
+        mediaTags: ArtTag[]
+        genreTags: ArtTag[]
+        otherTags: ArtTag[]
+        originalTags: ArtTag[]
+    }
+}
+const InterestTagsSettingForm: FC<InterestTagsSettingFormProps> = ({ defaultValues }) => {
+    const [selectedMedias, setSelectedMedias] = useState<ArtTag[]>(defaultValues.mediaTags)
+    const [selectedGenres, setSelectedGenres] = useState<ArtTag[]>(defaultValues.genreTags)
+    const [selectedOthers, setSelectedOthers] = useState<ArtTag[]>(defaultValues.otherTags)
+    const [originals, setOriginals] = useState<ArtTag[]>(defaultValues.originalTags)
+
+    const save = useMutate(async () => {
+        await handleUpdateInterestTags({
+            mediaTags: selectedMedias,
+            genreTags: selectedGenres,
+            otherTags: selectedOthers,
+            originalTags: originals,
+        })
+    }, {
+        loading: { toast: "設定中..." },
+        onSuccess: { toast: "設定しました！" },
+        onError: { toast: "設定できませんでした..." },
+    })
+    return (
+        <div>
+            <ArtTagForm
+                mediaTags={medias}
+                genreTags={getGenreTags(selectedMedias)}
+                otherTags={others}
+                selectedMediaTags={selectedMedias}
+                selectedGenreTags={selectedGenres}
+                selectedOtherTags={selectedOthers}
+                originalTags={originals}
+                onChangeSelectedMediaTags={setSelectedMedias}
+                onChangeSelectedGenreTags={setSelectedGenres}
+                onChangeSelectedOtherTags={setSelectedOthers}
+                onChangeOriginalTags={setOriginals}
+                actions={
+                    <div className={center({ mb: "6" })}>
+                        <MutateButton
+                            mutation={save}
+                            variant="filled"
+                            leftSection={<CheckIcon />}
+                        >
+                            興味のあるタグを保存
+                        </MutateButton>
+                    </div>
+                }
+            />
+        </div>
+    )
+}
+
+export default InterestTagsSettingForm

--- a/src/app/settings/interest-tags/actions.ts
+++ b/src/app/settings/interest-tags/actions.ts
@@ -1,0 +1,29 @@
+"use server"
+
+import { updateInterestTags } from '@/art/tag/interest/update';
+import { ArtTag } from '@/art/type';
+import { getSession } from '@/auth/server/auth';
+import { notImplementError } from '@/util/notImplement';
+
+export const handleUpdateInterestTags = async ({
+    mediaTags,
+    genreTags,
+    otherTags,
+    originalTags,
+}: {
+    mediaTags: ArtTag[],
+    genreTags: ArtTag[],
+    otherTags: ArtTag[],
+    originalTags: ArtTag[],
+}) => {
+    const session = await getSession()
+    if (!session) {
+        throw notImplementError(`ログインする必要があります`)
+    }
+    await updateInterestTags(session.user.id, [
+        ...mediaTags,
+        ...genreTags,
+        ...otherTags,
+        ...originalTags,
+    ])
+}

--- a/src/app/settings/interest-tags/page.tsx
+++ b/src/app/settings/interest-tags/page.tsx
@@ -1,0 +1,21 @@
+import { getSession } from "@/auth/server/auth"
+import InterestTagsSettingForm from "./InterestTagsSettingForm"
+import PleaseLogin from "@/app/art/[art_id]/appeal/PleaseLogin"
+import { getInterestTags } from "@/art/tag/interest/get"
+import { splitTags } from "@/art/tag/split"
+
+const InterestTagsSettingPage = async () => {
+    const session = await getSession()
+    if (!session) {
+        return <PleaseLogin />
+    }
+    const interestTags = await getInterestTags(session.user.id)
+    return (
+        <div>
+            <InterestTagsSettingForm
+                defaultValues={splitTags(interestTags)}
+            />
+        </div>
+    )
+}
+export default InterestTagsSettingPage

--- a/src/art/tag/interest/update.ts
+++ b/src/art/tag/interest/update.ts
@@ -1,0 +1,15 @@
+import { ArtTag } from "@/art/type"
+import { prisma } from "@/prisma"
+import { UserId } from "@/user/type"
+
+export const updateInterestTags = async (userId: UserId, tags: ArtTag[]) => {
+    await prisma.$transaction(async prisma => {
+        await Promise.all(tags.map(tag =>
+            prisma.interestTag.upsert({
+                where: { userId_tag: { userId, tag } },
+                create: { userId, tag },
+                update: { userId, tag, },
+            })
+        ))
+    })
+}

--- a/src/art/tag/split.ts
+++ b/src/art/tag/split.ts
@@ -1,0 +1,35 @@
+import { getGenreTags, medias, others } from "../components/tag/tags"
+import { ArtTag } from "../type"
+
+export const splitTags = (tags: ArtTag[]) => {
+    const mediaTags: ArtTag[] = []
+    const genreTags: ArtTag[] = []
+    const otherTags: ArtTag[] = []
+    // media と other
+    const notGroupedTags: ArtTag[] = []
+    tags.forEach((tag) => {
+        if (medias.includes(tag)) {
+            mediaTags.push(tag)
+        } else if (others.includes(tag)) {
+            otherTags.push(tag)
+        } else {
+            notGroupedTags.push(tag)
+        }
+    })
+    // genre
+    const genres = getGenreTags(mediaTags)
+    notGroupedTags.forEach((tag, index) => {
+        if (genres.includes(tag)) {
+            genreTags.push(tag)
+            notGroupedTags.splice(index, 1)
+        }
+    })
+    // originalTags
+    const originalTags: ArtTag[] = notGroupedTags
+    return {
+        mediaTags,
+        genreTags,
+        otherTags,
+        originalTags,
+    }
+}


### PR DESCRIPTION

## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #160 

## 変更内容

<!-- 
 変更した点を簡潔に記入してください
-->

## 動作確認の手順と項目

<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット

<!-- 
 見た目の変更がない場合は省略可 
-->

<img width="939" alt="スクリーンショット 2024-01-15 3 09 41" src="https://github.com/megane-s/minshumi-frontend/assets/81161390/6796876e-64e6-4fe4-b27a-25fc4191a404">


## 自己評価

出来を10点満点で自己評価:

7点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [ ] 実装できたのでチェックして欲しい。
- [ ] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [x] その他（下に記入）

時間ないのでレビューしない

## 備考

上の方の余白は共通部分のissue(https://github.com/megane-s/minshumi-frontend/issues/158) で実装 (https://github.com/megane-s/minshumi-frontend/issues/158#issuecomment-1890989340)
