### PR TITLE
[issue-199] 設定画面のアピールタブを実装

### DIFF
--- a/src/app/settings/appeals/AppealSettingForm.tsx
+++ b/src/app/settings/appeals/AppealSettingForm.tsx
@@ -1,0 +1,31 @@
+import { LikeArtImage } from "@/app/user/[user_id]/LikeArtList/LikeArtImage"
+import { ArtAppeal } from "@/art/type"
+import { Carousel, CarouselSlide } from "@/components/Carousel"
+import { FC } from "react"
+
+interface AppealSettingFormProps {
+    appeals: ArtAppeal[]
+}
+const AppealSettingForm: FC<AppealSettingFormProps> = ({ appeals }) => {
+    return (
+        <div>
+            <Carousel
+                slideSize="fit-content"
+                slideGap="sm"
+                align="start"
+                controlsOffset="0"
+            >
+                {appeals.map(art =>
+                    <CarouselSlide key={art.artId}>
+                        <LikeArtImage
+                            art={art}
+                            editable
+                        />
+                    </CarouselSlide>
+                )}
+            </Carousel>
+        </div>
+    )
+}
+
+export default AppealSettingForm

--- a/src/app/settings/appeals/page.tsx
+++ b/src/app/settings/appeals/page.tsx
@@ -1,0 +1,20 @@
+import PleaseLogin from "@/app/art/[art_id]/appeal/PleaseLogin"
+import { getSession } from "@/auth/server/auth"
+import AppealSettingForm from "./AppealSettingForm"
+import { getArtAppealsByUser } from "@/art/appeal/getByUser"
+
+const AppealSettingPage = async () => {
+    const session = await getSession()
+    if (!session) {
+        return <PleaseLogin />
+    }
+    const appeals = await getArtAppealsByUser(session.user.id)
+    return (
+        <div>
+            <AppealSettingForm
+                appeals={appeals}
+            />
+        </div>
+    )
+}
+export default AppealSettingPage

--- a/src/app/user/[user_id]/ArtDetailDialog.tsx
+++ b/src/app/user/[user_id]/ArtDetailDialog.tsx
@@ -1,16 +1,31 @@
-import { ArtAppeal } from "@/art/type"
-import { Dialog, DialogProps } from "@/components/Dialog"
+import { ArtAppeal, ArtId } from "@/art/type"
+import { Dialog, DialogProps, useDialog } from "@/components/Dialog"
 import LinkButton from "@/components/LinkButton"
 import { SectionTitle } from "@/components/SectionTitle"
 import Link from "next/link"
 import { FC } from "react"
 import Image from "next/image"
 import { flex } from "styled-system/patterns"
+import { Divider } from "@mantine/core"
+import { css } from "styled-system/css"
+import { Button } from "@/components/Button"
+import { Mutation, useMutate } from "@/util/client/useMutate"
+import MutateButton from "@/components/MutateButton"
+import { handleDeleteAppeal } from "./actions"
 
 interface ArtDetailDialogProps extends DialogProps {
     art: ArtAppeal
+    editable?: boolean
 }
-export const ArtDetailDialog: FC<ArtDetailDialogProps> = ({ art, ...dialogProps }) => {
+export const ArtDetailDialog: FC<ArtDetailDialogProps> = ({ art, editable = false, ...dialogProps }) => {
+    const deleteAppeal = useMutate(async () => {
+        await handleDeleteAppeal(art.artId)
+        dialogProps.onClose()
+    }, {
+        loading: { toast: "削除中" },
+        onSuccess: { toast: "アピールを削除しました" },
+        onError: { toast: "削除できませんでした" }
+    })
     return (
         <Dialog {...dialogProps}>
             <Link href={`/art/${art.artId}`} >
@@ -34,6 +49,47 @@ export const ArtDetailDialog: FC<ArtDetailDialogProps> = ({ art, ...dialogProps 
                 </div>
             </SectionTitle>
             {art.likePoint}
+            {editable &&
+                <Edit
+                    artId={art.artId}
+                    deleteMutation={deleteAppeal}
+                />
+            }
         </Dialog>
+    )
+}
+
+interface EditProps {
+    deleteMutation: Mutation
+    artId: ArtId
+}
+const Edit: FC<EditProps> = ({ deleteMutation, artId }) => {
+    const deleteConfirmDialog = useDialog()
+    return (
+        <div className={flex({ flexDir: "column", w: "full", align: "end", gap: "md" })}>
+            <LinkButton href={`/art/${artId}/appeal`} variant="gradient">
+                アピールを編集
+            </LinkButton>
+            <Divider className={css({ w: "full" })} />
+            <div>
+                <Button variant="outline" color="error" onClick={deleteConfirmDialog.onOpen}>
+                    削除
+                </Button>
+            </div>
+
+            <Dialog
+                {...deleteConfirmDialog.dialogProps}
+                title="アピールを削除してもいいですか？"
+            >
+                <div className={flex({ w: "full", justify: "flex-end", gap: "sm" })}>
+                    <Button onClick={deleteConfirmDialog.onClose}>
+                        キャンセル
+                    </Button>
+                    <MutateButton mutation={deleteMutation} variant="filled" color="error">
+                        削除する
+                    </MutateButton>
+                </div>
+            </Dialog>
+        </div>
     )
 }

--- a/src/app/user/[user_id]/ArtDetailDialog.tsx
+++ b/src/app/user/[user_id]/ArtDetailDialog.tsx
@@ -2,10 +2,10 @@ import { ArtAppeal } from "@/art/type"
 import { Dialog, DialogProps } from "@/components/Dialog"
 import LinkButton from "@/components/LinkButton"
 import { SectionTitle } from "@/components/SectionTitle"
-import { Flex } from "@mantine/core"
 import Link from "next/link"
 import { FC } from "react"
 import Image from "next/image"
+import { flex } from "styled-system/patterns"
 
 interface ArtDetailDialogProps extends DialogProps {
     art: ArtAppeal
@@ -24,14 +24,14 @@ export const ArtDetailDialog: FC<ArtDetailDialogProps> = ({ art, ...dialogProps 
             </Link>
 
             <SectionTitle>
-                <Flex w="100%" justify="space-between" align="center">
+                <div className={flex({ w: "100%", justify: "space-between", align: "center", my: "sm" })}>
                     <div>
                         {art.title}
                     </div>
                     <LinkButton variant="light" size="xs" href={`/art/${art.artId}`}>
                         作品のページへ
                     </LinkButton>
-                </Flex>
+                </div>
             </SectionTitle>
             {art.likePoint}
         </Dialog>

--- a/src/app/user/[user_id]/LikeArtList/LikeArtImage.tsx
+++ b/src/app/user/[user_id]/LikeArtList/LikeArtImage.tsx
@@ -9,8 +9,9 @@ import { css } from "styled-system/css"
 
 interface LikeArtImageProps {
     art: ArtAppeal
+    editable?: boolean
 }
-export const LikeArtImage: FC<LikeArtImageProps> = ({ art }) => {
+export const LikeArtImage: FC<LikeArtImageProps> = ({ art, editable = false }) => {
     const dialog = useDialog()
     return (
         <>
@@ -38,7 +39,11 @@ export const LikeArtImage: FC<LikeArtImageProps> = ({ art }) => {
                 </div>
             </div>
 
-            <ArtDetailDialog art={art} {...dialog.dialogProps} />
+            <ArtDetailDialog
+                art={art}
+                editable={editable}
+                {...dialog.dialogProps}
+            />
 
         </ >
     )

--- a/src/app/user/[user_id]/LikeArtList/LikeArtImage.tsx
+++ b/src/app/user/[user_id]/LikeArtList/LikeArtImage.tsx
@@ -40,7 +40,6 @@ export const LikeArtImage: FC<LikeArtImageProps> = ({ art }) => {
 
             <ArtDetailDialog art={art} {...dialog.dialogProps} />
 
-
         </ >
     )
 }

--- a/src/app/user/[user_id]/actions.ts
+++ b/src/app/user/[user_id]/actions.ts
@@ -1,5 +1,7 @@
 "use server"
 
+import { deleteArtAppeal } from "@/art/appeal/delete"
+import { ArtId } from "@/art/type"
 import { getSession } from "@/auth/server/auth"
 import { CreateBusinessCardCommentParams, createBusinessCardComment } from "@/businessCard/comment/create"
 import { deleteBusinessCardComment } from "@/businessCard/comment/delete"
@@ -96,4 +98,11 @@ export const handleCancelFollow = async (followUserId: UserId) => {
     if (!isFollowing) return
     await cancelFollow(followUserId, loginUserId)
     revalidatePath(`/user/${followUserId}`)
+}
+
+export const handleDeleteAppeal = async (artId: ArtId) => {
+    const session = await getSession()
+    if (!session) throw notImplementError(`ログインする必要があります。`)
+    await deleteArtAppeal(session.user.id, artId)
+    revalidatePath(`/user/${session.user.id}`)
 }

--- a/src/app/user/[user_id]/page.tsx
+++ b/src/app/user/[user_id]/page.tsx
@@ -120,7 +120,9 @@ const UserProfilePage = async ({ params }: PageProps) => {
                     : null
                 )}
             </Flex>
-            <WatchingArtList arts={watchingArts} />
+            <WatchingArtList
+                arts={watchingArts}
+            />
             {/* TODO 0件の時の表示 */}
 
             {comments && <>

--- a/src/art/appeal/delete.ts
+++ b/src/art/appeal/delete.ts
@@ -1,0 +1,10 @@
+import { prisma } from "@/prisma"
+import { UserId } from "@/user/type"
+import "server-only"
+import { ArtId } from "../type"
+
+export const deleteArtAppeal = async (userId: UserId, artId: ArtId) => {
+    await prisma.artAppeal.delete({
+        where: { userId_artId: { userId, artId } },
+    })
+}

--- a/src/util/client/useMutate.tsx
+++ b/src/util/client/useMutate.tsx
@@ -37,3 +37,7 @@ export const useMutate = <F extends ((...args: any[]) => Promise<any>)>(
     loading: options.loading,
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Mutation<Func extends ((...args: any[]) => Promise<any>) = (() => Promise<void>)> =
+  ReturnType<typeof useMutate<Func>>


### PR DESCRIPTION

## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #199 

## 変更内容

<!-- 
 変更した点を簡潔に記入してください
-->

## 動作確認の手順と項目

<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット

<!-- 
 見た目の変更がない場合は省略可 
-->

<img width="946" alt="スクリーンショット 2024-01-15 4 07 42" src="https://github.com/megane-s/minshumi-frontend/assets/81161390/faecd901-29ac-4cab-bc11-1cc496a2c1d8">


ちょっと寂しい...？

## 自己評価

出来を10点満点で自己評価:

5点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [ ] 実装できたのでチェックして欲しい。
- [x] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [x] その他（下に記入）

時間がないのでレビューしない

## 備考

上の方の余白は共通部分のissue(https://github.com/megane-s/minshumi-frontend/issues/158) で実装 (https://github.com/megane-s/minshumi-frontend/issues/158#issuecomment-1890989340)