### PR TITLE
[issue-241] 作品登録パネルの修正

### DIFF
--- a/src/app/art/new/layout.tsx
+++ b/src/app/art/new/layout.tsx
@@ -1,11 +1,17 @@
 import { PageTitle } from "@/components/PageTitle"
 import { ReactNode } from "react"
 import { NewArtProgressProvider } from "./NewArtProgress/provider"
+import { getSession } from "@/auth/server/auth"
+import PleaseLogin from "../[art_id]/appeal/PleaseLogin"
 
 interface PageProps {
     children: ReactNode
 }
-const NewArtLayout = ({ children }: PageProps) => {
+const NewArtLayout = async ({ children }: PageProps) => {
+    const session = await getSession()
+    if (!session) {
+        return <PleaseLogin />
+    }
     return (
         <div>
             <PageTitle my="lg">


### PR DESCRIPTION

## 目的・解決すること

<!-- 
 issueの対応の場合は #の後にissue番号をつけて close #1234 のようになるようにしてください。 
-->

close #241 

## 変更内容
作品登録パネルをクリックしたときにログインしていないユーザーにはログインを催促するように修正しました。
<!-- 
 変更した点を簡潔に記入してください
-->

## 動作確認の手順と項目
ログインした状態で作品登録パネルをクリックすると作品登録が出来る。
ログインしていない状態で作品登録パネルをクリックするとログインを催促する画面が出る。
<!-- 
 レビュワーが動作確認するために、動作確認の手順や何を確認すればいいかを記述してください。
 （動作確認手順等の是非も含めてレビューします） 
 例)
   1. http://localhost:300/art/test-art-1 や http://localhost:300/art/test-art-2 にアクセス
   2. 表示が崩れていないかやページの内容が動的に変わるかを確認
     - 画像の位置やサイズ
     - 作品IDを変えると表示される作品名や概要が変わる
-->

## スクリーンショット
![スクリーンショット 2024-01-22 120307](https://github.com/megane-s/minshumi-frontend/assets/148510481/e1b36abd-1f22-4c7c-83ca-79a1fbf425a9)
ログインなし
![スクリーンショット 2024-01-22 120403](https://github.com/megane-s/minshumi-frontend/assets/148510481/c38743b9-2f50-4c37-b386-4ab6e50803ff)
ログインあり
<!-- 
 見た目の変更がない場合は省略可 
-->

## 自己評価

出来を10点満点で自己評価:

10点

<!-- 該当箇所の -[ ] を - [x] にしてください。（チェックがつきます） -->

- [x] 実装できたのでチェックして欲しい。
- [ ] 心配なところがいくつかある。
- [ ] あまり理解できていないがissueなどに書いてあるとおり やった。
- [ ] その他（下に記入）

## 備考
